### PR TITLE
Fix build on Linux, Blackberry

### DIFF
--- a/file/zip_read.cpp
+++ b/file/zip_read.cpp
@@ -1,9 +1,5 @@
 #include <stdio.h>
 
-#ifndef _WIN32
-#include <zip.h>
-#endif
-
 #include "base/basictypes.h"
 #include "base/logging.h"
 #include "file/zip_read.h"

--- a/file/zip_read.h
+++ b/file/zip_read.h
@@ -1,6 +1,6 @@
 // TODO: Move much of this code to vfs.cpp
 
-#ifndef _WIN32
+#ifdef ANDROID
 #include <zip.h>
 #endif
 
@@ -21,7 +21,7 @@ public:
 	virtual std::string toString() const = 0;
 };
 
-#ifndef _WIN32
+#ifdef ANDROID
 uint8_t *ReadFromZip(zip *archive, const char* filename, size_t *size);
 class ZipAssetReader : public AssetReader {
 public:


### PR DESCRIPTION
Wasn't building if a system zip.h was not found since libzip was removed but zip is only needed on Android.
