### PR TITLE
Fix cityhash build

### DIFF
--- a/ext/cityhash/city.cpp
+++ b/ext/cityhash/city.cpp
@@ -493,7 +493,7 @@ uint128 CityHash128(const char *s, size_t len) {
 }
 
 #ifdef __SSE4_2__
-#include <citycrc.h>
+#include "citycrc.h"
 #include <nmmintrin.h>
 
 // Requires len >= 240.


### PR DESCRIPTION
This fixes the compilation error when SSE_4_2 is defined : 

```
fatal error: citycrc.h: file not found
```
