### PR TITLE
Another memory leak fixed in etctool

### DIFF
--- a/ext/etcpack/etctool.cpp
+++ b/ext/etcpack/etctool.cpp
@@ -612,9 +612,10 @@ void compressImageFile(uint8 *img,int width,int height,char *dstfile, int expand
 			printf("\n");
 
 		fclose(f);
-	free(imgdec);
-	printf("Saved file <%s>.\n",dstfile);
+		printf("Saved file <%s>.\n",dstfile);
 	}
+	
+	free(imgdec);
 }
 
 double calculatePSNR(uint8 *lossyimg, uint8 *origimg, int width, int height)


### PR DESCRIPTION
imgdec = (unsigned char_) malloc(expandedwidth_expandedheight*3);
is called before the if statement "if((f=fopen(dstfile,"wb")))"

If the file 'f' failed in the if statement, it would never be freed (since "free(imgdec)" was within that if block.
