### PR TITLE
Use a custom inet_pton and avoid inet_ntoa for now

### DIFF
--- a/net/http_client.cpp
+++ b/net/http_client.cpp
@@ -1,9 +1,5 @@
 #include "net/http_client.h"
 
-// for inet_pton
-#undef _WIN32_WINNT
-#define _WIN32_WINNT 0x600
-
 #ifndef _WIN32
 #include <arpa/inet.h>
 #include <sys/socket.h>
@@ -49,7 +45,7 @@ bool Connection::Resolve(const char *host, int port) {
 	}
 	// VLOG(1) << "Resolved " << host << " to " << ip;
 	remote_.sin_family = AF_INET;
-	int tmpres = inet_pton(AF_INET, ip, (void *)(&(remote_.sin_addr.s_addr)));
+	int tmpres = net::inet_pton(AF_INET, ip, (void *)(&(remote_.sin_addr.s_addr)));
 	CHECK_GE(tmpres, 0);	// << "inet_pton failed";
 	CHECK_NE(0, tmpres);	// << ip << " not a valid IP address";
 	remote_.sin_port = htons(port);

--- a/net/resolve.cpp
+++ b/net/resolve.cpp
@@ -45,11 +45,13 @@ char *DNSResolveTry(const char *host, const char **err)
 	int iplen = 15; //XXX.XXX.XXX.XXX
 	char *ip = (char *)malloc(iplen+1);
 	memset(ip, 0, iplen+1);
-	if(inet_ntop(AF_INET, (void *)hent->h_addr_list[0], ip, iplen) == NULL)
+	char *iptoa = inet_ntoa(*(in_addr *)hent->h_addr_list[0]);
+	if (iptoa == NULL)
 	{
 		*err = "Can't resolve host";
 		return NULL;
 	}
+	strncpy(ip, iptoa, iplen);
 	return ip;
 }
 
@@ -63,6 +65,78 @@ char *DNSResolve(const char *host)
 		exit(1);
 	}
 	return ip;
+}
+
+int inet_pton(int af, const char* src, void* dst)
+{
+	if (af == AF_INET)
+	{
+		BYTE *ip = (BYTE *)dst;
+		int k = 0, x = 0;
+		char ch;
+		for (int i = 0; (ch = src[i]) != 0; i++)
+		{
+			if (ch == '.')
+			{
+				ip[k++] = x;
+				if (k == 4)
+					return 0;
+				x = 0;
+			}
+			else if (ch < '0' || ch > '9')
+				return 0;
+			else
+				x = x * 10 + ch - '0';
+			if (x > 255)
+				return 0;
+		}
+		ip[k++] = x;
+		if (k != 4)
+			return 0;
+	}
+	else if (af == AF_INET6)
+	{
+		unsigned short* ip = ( unsigned short* )dst;
+		int i;
+		for (i = 0; i < 8; i++) ip[i] = 0;
+		int k = 0;
+		unsigned int x = 0;
+		char ch;
+		int marknum = 0;
+		for (i = 0; src[i] != 0; i++)
+		{
+			if (src[i] == ':')
+				marknum++;
+		}
+		for (i = 0; (ch = src[i]) != 0; i++)
+		{
+			if (ch == ':')
+			{
+				x = ((x & 0xFF00) >> 8) | ((x & 0x00FF) << 8);
+				ip[k++] = x;
+				if (k == 8)
+					return 0;
+				x = 0;
+				if (i > 0 && src[i - 1] == ':')
+					k += 7 - marknum;
+			}
+			else if (ch >= '0' && ch <= '9')
+				x = x * 16 + ch - '0';
+			else if (ch >= 'a' && ch <= 'f')
+				x = x * 16 + ch - 'a' + 10;
+			else if (ch >= 'A' && ch <= 'F')
+				x = x * 16 + ch - 'A' + 10;
+			else
+				return 0;
+			if (x > 0xFFFF)
+				return 0;
+		}
+		x = ((x & 0xFF00) >> 8) | ((x & 0x00FF) << 8);
+		ip[k++] = x;
+		if (k != 8)
+			return 0;
+	}
+	return 1;
 }
 
 }

--- a/net/resolve.h
+++ b/net/resolve.h
@@ -10,5 +10,7 @@ void Shutdown();
 // use free() to free the returned string.
 char *DNSResolveTry(const char *host, const char **err);
 char *DNSResolve(const char *host);
+
+int inet_pton(int af, const char* src, void* dst);
 }  // namespace net
 #endif


### PR DESCRIPTION
When/if ipv6 is needed we can fix inet_ntop.  Not heavily tested, but makes Windows XP run again without errors.

-[Unknown]
