### PR TITLE
Try to use larger buffer size for streaming audio in OpenSL ES

### DIFF
--- a/android/native-audio-so.cpp
+++ b/android/native-audio-so.cpp
@@ -29,7 +29,7 @@ static SLAndroidSimpleBufferQueueItf bqPlayerBufferQueue;
 static SLMuteSoloItf bqPlayerMuteSolo;
 static SLVolumeItf bqPlayerVolume;
 
-#define BUFFER_SIZE 512
+#define BUFFER_SIZE 4096
 #define BUFFER_SIZE_IN_SAMPLES (BUFFER_SIZE / 2)
 
 // Double buffering.


### PR DESCRIPTION
Hopefully can solve audio clicking with Jelly Bean.
