### PR TITLE
Fix compilation errors in 32-bit debug

### DIFF
--- a/math/lin/aabb.cpp
+++ b/math/lin/aabb.cpp
@@ -74,7 +74,7 @@ bool AABB::IntersectRay(const Ray &ray, float &tnear, float &tfar) const {
 
 
 // Possible orientation of the splitting plane in the interior node of the kd-tree, 
-// ”No axis” denotes a leaf. 
+// "No axis" denotes a leaf.
 enum Axes
 {
 	Xaxis, 

--- a/native.vcxproj
+++ b/native.vcxproj
@@ -79,6 +79,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\zlib;..\ext\zlib;..\native;..\RollerballGL;..\native\ext\glew;..\SDL\include;..\libpng;%(AdditionalIncludeDirectories);</AdditionalIncludeDirectories>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>


### PR DESCRIPTION
Oops, sorry.  I've been using x64 debug for a while so I missed this.  Darn.

See hrydgard/ppsspp#1678.  But x64 does work, not sure what that's about.

Alternatively, I can undo the cityhash thing, not sure if you use edit and continue with this code (I don't.)

-[Unknown]
