### PR TITLE
Hold Tab to Unthrottle

### DIFF
--- a/input/input_state.h
+++ b/input/input_state.h
@@ -29,6 +29,8 @@ enum {
 
 	PAD_BUTTON_LEFT_THUMB = 1 << 18,   // Click left thumb stick on X360
 	PAD_BUTTON_RIGHT_THUMB = 1 << 19,   // Click right thumb stick on X360
+	PAD_BUTTON_UNTHROTTLE = 1 << 20, // Click Tab to unthrottle
+
 };
 
 #ifndef MAX_POINTERS


### PR DESCRIPTION
In combination with "Custom Fps Limiter" , holding tab unthrottles the emulator.
