### PR TITLE
Use getaddrinfo() instead of gethostbyname()

### DIFF
--- a/net/http_client.h
+++ b/net/http_client.h
@@ -16,6 +16,7 @@
 #include <arpa/inet.h>
 #endif
 #include <sys/socket.h>
+#include <netdb.h>
 #endif
 
 namespace net {
@@ -43,7 +44,7 @@ protected:
 	std::string host_;
 	int port_;
 
-	sockaddr_in remote_;
+	addrinfo *resolved_;
 
 private:
 	uintptr_t sock_;

--- a/net/resolve.h
+++ b/net/resolve.h
@@ -1,5 +1,8 @@
-#ifndef _NET_RESOLVE_H
-#define _NET_RESOLVE_H
+#pragma once
+
+#include <string>
+
+struct addrinfo;
 
 namespace net {
 
@@ -11,6 +14,8 @@ void Shutdown();
 char *DNSResolveTry(const char *host, const char **err);
 char *DNSResolve(const char *host);
 
+bool DNSResolve(const std::string &host, const std::string &service, addrinfo **res, std::string &error);
+void DNSResolveFree(addrinfo *res);
+
 int inet_pton(int af, const char* src, void* dst);
 }  // namespace net
-#endif


### PR DESCRIPTION
The latter is not re-entrant, so not thread-safe.  This fixes crashes on non-Windows, and at least assertions (if not crashes) on Windows when server reporting is enabled.  Oops.

At the same time, support round-robin DNS in a sort of trivial way.

Left the old API there in case you're using it, but might be better to clean it up if you're not.

-[Unknown]
