### PR TITLE
Avoid a usleep loop, send 0s instead in Android audio

### DIFF
--- a/android/native-audio-so.cpp
+++ b/android/native-audio-so.cpp
@@ -50,10 +50,9 @@ static void bqPlayerCallback(SLAndroidSimpleBufferQueueItf bq, void *context) {
 
 	int nextSamples = audioCallback(buffer[curBuffer], framesPerBuffer);
 	// We can't enqueue nothing, the callback will never be called again.
-	// Delay until we get some audio.
-	while (nextSamples == 0) {
-		usleep(40);
-		nextSamples = audioCallback(buffer[curBuffer], framesPerBuffer);
+	if (nextSamples == 0) {
+		nextSamples = 0x100;
+		memset(buffer[curBuffer], 0, nextSamples * 2 * sizeof(short));
 	}
 
 	short *nextBuffer = buffer[curBuffer];


### PR DESCRIPTION
Doesn't hurt audio quality all that much, may improve perf.  Wasn't sure what value to use, but I see games using 0x100 queue sizes a lot so... that works for me?

I'm not actually sure if this helps perf, though.

-[Unknown]
