### PR TITLE
Visual Studio 2012 build fix.

### DIFF
--- a/thread/thread.h
+++ b/thread/thread.h
@@ -245,7 +245,12 @@ private:
 		void Run() { func(); }
 
 	private:
+// Visual Studio 2012 needs this, or else it complains about losing const-volatile qualifiers.
+#if _MSC_VER >= 1700
 		C func;
+#else
+		C const func;
+#endif
 	};
 
 	template <typename C, typename A>


### PR DESCRIPTION
Without this, I get this error:

Error   1   error C3848: expression having type 'const std::_Bind<_Forced,_Ret,_Fun,_V0_t,_V1_t,_V2_t,_V3_t,_V4_t,_V5_t,<unnamed-symbol>>' would lose some const-volatile qualifiers in order to call 'void std::_Bind<_Forced,_Ret,_Fun,_V0_t,_V1_t,_V2_t,_V3_t,_V4_t,_V5_t,<unnamed-symbol>>::operator ()(void)'  native\thread\thread.h  245 1   native

Does it really need to be const? Or perhaps, should I just ifdef this?
