### PR TITLE
An (ugly) hack to make some Bluetooth Gamepads to work.

### DIFF
--- a/android/src/com/henrikrydgard/libnative/NativeActivity.java
+++ b/android/src/com/henrikrydgard/libnative/NativeActivity.java
@@ -356,7 +356,7 @@ public class NativeActivity extends Activity {
             return inputPlayerB;
         }
 
-        return null;
+        return inputPlayerA;
     }
 
     // We grab the keys before onKeyDown/... even see them. This is also better because it lets us


### PR DESCRIPTION
The problem with BT gamepads is the fact they tend to show up as multiple gamepads, while PPSSPP only recognises two. Until the whole gamepad code is reworked, this will allow them to work by always returning inputPlayerA in case of an additional recognised gamepad. Fixes PPSSPP issue #3314
