### PR TITLE
Removed broken scaling on Linux Qt build

### DIFF
--- a/base/QtMain.cpp
+++ b/base/QtMain.cpp
@@ -68,6 +68,8 @@ float CalculateDPIScale()
 	// Sane default rather than check DPI
 #ifdef __SYMBIAN32__
 	return 1.4f;
+#elif defined(Q_WS_X11)
+	return 1.0f;
 #else
 	return 1.2f;
 #endif


### PR DESCRIPTION
Added an #ifdef to disable ui scaling (force scale to 1) on linux Qt platforms where it causes severe graphical glitches.
