### PR TITLE
Skip blank lines in IniFile::GetKeys().

### DIFF
--- a/file/ini_file.cpp
+++ b/file/ini_file.cpp
@@ -360,7 +360,8 @@ bool IniFile::GetKeys(const char* sectionName, std::vector<std::string>& keys) c
 	{
 		std::string key;
 		ParseLine(*liter, &key, 0, 0);
-		keys.push_back(key);
+		if (!key.empty())
+			keys.push_back(key);
 	}
 	return true;
 }


### PR DESCRIPTION
Fixes hrydgard/ppsspp#3783.

-[Unknown]
