### PR TITLE
Add an auto class for net::Init().

### DIFF
--- a/net/http_client.cpp
+++ b/net/http_client.cpp
@@ -316,34 +316,30 @@ void Download::Do(std::shared_ptr<Download> self) {
 		progress_ = 1.0f;
 		return;
 	}
-	net::Init();
+	net::AutoInit netInit;
 
 	http::Client client;
 	if (!client.Resolve(fileUrl.Host().c_str(), 80)) {
 		ELOG("Failed resolving %s", url_.c_str());
 		failed_ = true;
 		progress_ = 1.0f;
-		net::Shutdown();
 		return;
 	}
 
 	if (cancelled_) {
 		SetFailed(-1);
-		net::Shutdown();
 		return;
 	}
 
 	if (!client.Connect()) {
 		ELOG("Failed connecting to server.");
 		resultCode_ = -1;
-		net::Shutdown();
 		progress_ = 1.0f;
 		return;
 	}
 
 	if (cancelled_) {
 		SetFailed(-1);
-		net::Shutdown();
 		return;
 	}
 
@@ -359,7 +355,6 @@ void Download::Do(std::shared_ptr<Download> self) {
 	}
 
 	resultCode_ = resultCode;
-	net::Shutdown();
 	progress_ = 1.0f;
 }
 

--- a/net/resolve.h
+++ b/net/resolve.h
@@ -10,6 +10,15 @@ namespace net {
 void Init();
 void Shutdown();
 
+struct AutoInit {
+	AutoInit() {
+		Init();
+	}
+	~AutoInit() {
+		Shutdown();
+	}
+};
+
 // use free() to free the returned string.
 char *DNSResolveTry(const char *host, const char **err);
 char *DNSResolve(const char *host);


### PR DESCRIPTION
Fixes http::Client destructing after net::Shutdown(), calling freeaddrinfo() too late.

-[Unknown]
