### PR TITLE
fixed the 4xMSAA crash on android

### DIFF
--- a/android/src/com/henrikrydgard/libnative/NativeActivity.java
+++ b/android/src/com/henrikrydgard/libnative/NativeActivity.java
@@ -249,6 +249,10 @@ public class NativeActivity extends Activity {
         NativeApp.resized(size.x, size.y);
         
         mGLSurfaceView = new NativeGLView(this);
+        //setup the GLSurface and ask android for the correct 
+        //number of bits for r, g, b, a, depth and stencil components
+        mGLSurfaceView.setEGLConfigChooser(8, 8, 8, 8, 16, 8);
+        
 		nativeRenderer = new NativeRenderer(this);
         mGLSurfaceView.setRenderer(nativeRenderer);
         setContentView(mGLSurfaceView);


### PR DESCRIPTION
This fixes the crash on enabling 4x MSAA in developer mode. It may also fix some other bugs, since this is the correct way to setup a glSurfaceView.
