### PR TITLE
Use wide paths on Win32.

### DIFF
--- a/file/ini_file.cpp
+++ b/file/ini_file.cpp
@@ -415,6 +415,8 @@ bool IniFile::Load(const char* filename)
 	std::ifstream in;
 #ifdef _WIN32
 	in.open(ConvertUTF8ToWString(filename), std::ios::in);
+#else
+	in.open(filename, std::ios::in);
 #endif
 	if (in.fail()) return false;
 


### PR DESCRIPTION
Without this, it's impossible to load ini files from directories that can be represented with UTF8/wchars.
