### PR TITLE
Qt: Don't crash if audio feed is null

### DIFF
--- a/base/QtMain.h
+++ b/base/QtMain.h
@@ -198,11 +198,14 @@ public:
 		output = new QAudioOutput(fmt);
 		output->setBufferSize(mixlen);
 		feed = output->start();
-		timer = startTimer(1000*AUDIO_SAMPLES / AUDIO_FREQ);
+		if (feed != NULL)
+			timer = startTimer(1000*AUDIO_SAMPLES / AUDIO_FREQ);
 	}
 	~MainAudio() {
-		killTimer(timer);
-		feed->close();
+		if (feed != NULL) {
+			killTimer(timer);
+			feed->close();
+		}
 		output->stop();
 		delete output;
 		free(mixbuf);


### PR DESCRIPTION
Not sure why I get null, very possibly I have not configured any audio devices.

The docs for QAudioOutput::start() don't even mention anything about returning null...

-[Unknown]
