### PR TITLE
City hash android fix

### DIFF
--- a/ext/cityhash/city.cpp
+++ b/ext/cityhash/city.cpp
@@ -47,6 +47,12 @@ static uint32 UNALIGNED_LOAD32(const char *p) {
   return result;
 }
 
+// Urgh! Why is this needed?
+#ifdef ANDROID
+#ifndef UINT64_C
+#define UINT64_C(c) (c ## ULL)
+#endif
+#endif
 #ifdef _MSC_VER
 #define bswap_32(x) _byteswap_ulong(x)
 #define bswap_64(x) _byteswap_uint64(x)


### PR DESCRIPTION
The build breaks on building for android

```
Compile++ thumb  : ppsspp_jni <= ArmEmitter.cpp
../native/ext/cityhash/city.cpp: In function 'uint64 HashLen33to64(char const*, size_t)':
../native/ext/cityhash/city.cpp:335:14: error: 'UINT64_C' was not declared in this scope
```

So I redefined UNIT64_C (as it's done in __sceNet.h)
