### PR TITLE
UIScreen: Provide a default sendMessage which handles the language message.

### DIFF
--- a/ui/ui_screen.cpp
+++ b/ui/ui_screen.cpp
@@ -95,6 +95,12 @@ void UIScreen::axis(const AxisInput &axis) {
 	}
 }
 
+void UIScreen::sendMessage(const char *message, const char* value) {
+	if (!strcmp(message, "language")) {
+		screenManager()->RecreateAllViews();
+	}
+}
+
 UI::EventReturn UIScreen::OnBack(UI::EventParams &e) {
 	screenManager()->finishDialog(this, DR_OK);
 	return UI::EVENT_DONE;

--- a/ui/ui_screen.h
+++ b/ui/ui_screen.h
@@ -15,6 +15,7 @@ public:
 	virtual void touch(const TouchInput &touch);
 	virtual void key(const KeyInput &touch);
 	virtual void axis(const AxisInput &touch);
+	virtual void sendMessage(const char *message, const char* value);
 
 	// Some useful default event handlers
 	UI::EventReturn OnBack(UI::EventParams &e);


### PR DESCRIPTION
This way, any screens derived from it get the screen refreshed "for free"(or if they provide their own sendMessage, they just make a call to this and voila, refreshed screen).
