### PR TITLE
allow checkboxes to be force-toggled

### DIFF
--- a/ui/view.cpp
+++ b/ui/view.cpp
@@ -383,9 +383,13 @@ void PopupHeader::Draw(UIContext &dc) {
 	dc.Draw()->DrawImageStretch(dc.theme->whiteImage, bounds_.x, bounds_.y2()-2, bounds_.x2(), bounds_.y2(), dc.theme->popupTitle.fgColor);
 }
 
-EventReturn CheckBox::OnClicked(EventParams &e) {
+void CheckBox::Toggle(){
 	if (toggle_)
 		*toggle_ = !(*toggle_);
+};
+
+EventReturn CheckBox::OnClicked(EventParams &e) {
+	Toggle();
 	return EVENT_CONTINUE;  // It's safe to keep processing events.
 }
 

--- a/ui/view.h
+++ b/ui/view.h
@@ -600,7 +600,8 @@ public:
 	virtual void Draw(UIContext &dc);
 
 	EventReturn OnClicked(EventParams &e);
-
+	//allow external agents to toggle the checkbox
+	void Toggle();
 private:
 	bool *toggle_;
 	std::string text_;


### PR DESCRIPTION
This is going to be used to fix the check box bug in the Touch Control Visibility screen. see [this](https://github.com/hrydgard/ppsspp/issues/4277)
