### PR TITLE
Add Launch{Browser,Market,Email} support on Linux

### DIFF
--- a/base/PCMain.cpp
+++ b/base/PCMain.cpp
@@ -11,6 +11,7 @@
 #else
 #include <pwd.h>
 #include <unistd.h>
+#include <stdlib.h>
 #endif
 
 #include <string>
@@ -228,6 +229,9 @@ void LaunchBrowser(const char *url)
 {
 #ifdef _WIN32
 	ShellExecute(NULL, "open", url, NULL, NULL, SW_SHOWNORMAL);
+#elif __linux__
+	std::string command = std::string("xdg-open ") + url;
+	system(command.c_str());
 #else
 	ILOG("Would have gone to %s but LaunchBrowser is not implemented on this platform", url);
 #endif
@@ -237,6 +241,9 @@ void LaunchMarket(const char *url)
 {
 #ifdef _WIN32
 	ShellExecute(NULL, "open", url, NULL, NULL, SW_SHOWNORMAL);
+#elif __linux__
+	std::string command = std::string("xdg-open ") + url;
+	system(command.c_str());
 #else
 	ILOG("Would have gone to %s but LaunchMarket is not implemented on this platform", url);
 #endif
@@ -246,6 +253,9 @@ void LaunchEmail(const char *email_address)
 {
 #ifdef _WIN32
 	ShellExecute(NULL, "open", (std::string("mailto:") + email_address).c_str(), NULL, NULL, SW_SHOWNORMAL);
+#elif __linux__
+	std::string command = std::string("xdg-open mailto:") + email_address;
+	system(command.c_str());
 #else
 	ILOG("Would have opened your email client for %s but LaunchEmail is not implemented on this platform", email_address);
 #endif


### PR DESCRIPTION
Modern Linux desktop should implement a xdg-open program, that should open an
URL on the default desktop program.

The documentation of xdg-open says that we should supply xdg-open script on
our installation script for fallback purposes, but I don't think this is
really necessary: anyone using a reasonable recently DE on Linux should have
xdg-utils installed.

More info: http://cgit.freedesktop.org/xdg/xdg-utils/tree/README
