### PR TITLE
disable non-menu Main Window under Windows

### DIFF
--- a/base/QtMain.cpp
+++ b/base/QtMain.cpp
@@ -109,7 +109,7 @@ Q_DECL_EXPORT int main(int argc, char *argv[])
 #endif
 	NativeInit(argc, (const char **)argv, savegame_dir, assets_dir, "BADCOFFEE");
 
-#if !defined(Q_OS_LINUX) || defined(ARM)
+#if defined(ARM)
 	MainUI w;
 	w.resize(pixel_xres, pixel_yres);
 #ifdef ARM


### PR DESCRIPTION
This change only makes sense if the changes from fcf2c6b466f053c7e094401ef7897873441255b1 are also pulled. It disables the isolated MainUI under Windows if Qt is build, because I think that the Qt version of Windows should be the same as the Linux version.
