### PR TITLE
Add really basic float support to expr parser

### DIFF
--- a/math/expression_parser.h
+++ b/math/expression_parser.h
@@ -6,12 +6,19 @@
 typedef std::pair<uint32,uint32> ExpressionPair;
 typedef std::vector<ExpressionPair> PostfixExpression;
 
+enum ExpressionType
+{
+	EXPR_TYPE_UINT = 0,
+	EXPR_TYPE_FLOAT = 2,
+};
+
 class IExpressionFunctions
 {
 public:
 	virtual bool parseReference(char* str, uint32& referenceIndex) = 0;
 	virtual bool parseSymbol(char* str, uint32& symbolValue) = 0;
 	virtual uint32 getReferenceValue(uint32 referenceIndex) = 0;
+	virtual ExpressionType getReferenceType(uint32 referenceIndex) = 0;
 	virtual bool getMemoryValue(uint32 address, int size, uint32& dest, char* error) = 0;
 };
 


### PR DESCRIPTION
Requires update to consumers, though (even just a stub returning 0.)

Did this fairly quickly, trying not to "break the world" of the parser, but it should work okay.

@Kingcom: hope this is okay.

-[Unknown]
