### PR TITLE
Fix ATIClampBug being true on NVIDIA/etc. cards

### DIFF
--- a/gfx_es2/gl_state.cpp
+++ b/gfx_es2/gl_state.cpp
@@ -285,7 +285,7 @@ void CheckGLExtensions() {
 		gl_extensions.FBO_ARB = strstr(extString, "GL_ARB_framebuffer_object") != 0;
 		gl_extensions.FBO_EXT = strstr(extString, "GL_EXT_framebuffer_object") != 0;
 		gl_extensions.PBO_ARB = strstr(extString, "GL_ARB_pixel_buffer_object") != 0;
-		gl_extensions.ATIClampBug = ((strncmp (renderer, "ATI RADEON X", 12) != 0) || (strncmp (renderer, "ATI MOBILITY RADEON X",21) != 0));
+		gl_extensions.ATIClampBug = ((strncmp(renderer, "ATI RADEON X", 12) == 0) || (strncmp(renderer, "ATI MOBILITY RADEON X", 21) == 0));
 	}
 #endif
 


### PR DESCRIPTION
I assume the logic was inversed by accident.

I was puzzling over why S/T wrapping just was refusing to work for me, and I eventually realized that this was true, even though I'm on an NVIDIA card.

@DanyalZia, I assume that it is the ATI RADEON X / ATI MOBILITY RADEON X cards that have this bug?  Or are those the ATI cards that don't?  Either way, non-ATI cards should not have this set to true for sure...

-[Unknown]
