### PR TITLE
Explicitly check those ATI devices that claims to support npot

### DIFF
--- a/gfx_es2/gl_state.cpp
+++ b/gfx_es2/gl_state.cpp
@@ -196,7 +196,9 @@ void CheckGLExtensions() {
 #endif
 
 	// Check the desktop extension instead of the OES one. They are very similar.
-	gl_extensions.OES_texture_npot = strstr(extString, "GL_ARB_texture_non_power_of_two") != 0;
+	// Also explicitly check those ATI devices that claims to support npot
+	gl_extensions.OES_texture_npot = strstr(extString, "GL_ARB_texture_non_power_of_two") != 0
+		&& !(((strncmp(renderer, "ATI RADEON X", 12) == 0) || (strncmp(renderer, "ATI MOBILITY RADEON X", 21) == 0)));
 
 	gl_extensions.NV_draw_texture = strstr(extString, "GL_NV_draw_texture") != 0;
 	gl_extensions.ARB_blend_func_extended = strstr(extString, "GL_ARB_blend_func_extended") != 0;


### PR DESCRIPTION
This fixes GTA VCS on those devices which gets broken with your previous commit.
