### PR TITLE
Allow customizing the tab left/right keys

### DIFF
--- a/input/input_state.cpp
+++ b/input/input_state.cpp
@@ -44,10 +44,17 @@ int MapPadButtonFixed(int keycode) {
 
 std::vector<keycode_t> confirmKeys;
 std::vector<keycode_t> cancelKeys;
+std::vector<keycode_t> tabLeftKeys;
+std::vector<keycode_t> tabRightKeys;
 
-void SetConfirmCancelKeys(std::vector<keycode_t> confirm, std::vector<keycode_t> cancel) {
+void SetConfirmCancelKeys(const std::vector<keycode_t> &confirm, const std::vector<keycode_t> &cancel) {
 	confirmKeys = confirm;
 	cancelKeys = cancel;
+}
+
+void SetTabLeftRightKeys(const std::vector<keycode_t> &tabLeft, const std::vector<keycode_t> &tabRight) {
+	tabLeftKeys = tabLeft;
+	tabRightKeys = tabRight;
 }
 
 uint32_t ButtonTracker::Update() {

--- a/input/input_state.h
+++ b/input/input_state.h
@@ -180,4 +180,7 @@ extern ButtonTracker g_buttonTracker;
 // Is there a nicer place for this stuff? It's here to avoid dozens of linking errors in UnitTest..
 extern std::vector<keycode_t> confirmKeys;
 extern std::vector<keycode_t> cancelKeys;
-void SetConfirmCancelKeys(std::vector<keycode_t> confirm, std::vector<keycode_t> cancel);
+extern std::vector<keycode_t> tabLeftKeys;
+extern std::vector<keycode_t> tabRightKeys;
+void SetConfirmCancelKeys(const std::vector<keycode_t> &confirm, const std::vector<keycode_t> &cancel);
+void SetTabLeftRightKeys(const std::vector<keycode_t> &tabLeft, const std::vector<keycode_t> &tabRight);

--- a/ui/view.cpp
+++ b/ui/view.cpp
@@ -202,11 +202,35 @@ void Clickable::Touch(const TouchInput &input) {
 // TODO: O/X confirm preference for xperia play?
 
 bool IsAcceptKeyCode(int keyCode) {
-	return std::find(confirmKeys.begin(), confirmKeys.end(), (keycode_t)keyCode) != confirmKeys.end();
+	if (confirmKeys.empty()) {
+		return keyCode == NKCODE_SPACE || keyCode == NKCODE_ENTER || keyCode == NKCODE_Z || keyCode == NKCODE_BUTTON_A || keyCode == NKCODE_BUTTON_CROSS || keyCode == NKCODE_BUTTON_1;
+	} else {
+		return std::find(confirmKeys.begin(), confirmKeys.end(), (keycode_t)keyCode) != confirmKeys.end();
+	}
 }
 
 bool IsEscapeKeyCode(int keyCode) {
-	return std::find(cancelKeys.begin(), cancelKeys.end(), (keycode_t)keyCode) != cancelKeys.end();
+	if (cancelKeys.empty()) {
+		return keyCode == NKCODE_ESCAPE || keyCode == NKCODE_BACK || keyCode == NKCODE_BUTTON_CIRCLE || keyCode == NKCODE_BUTTON_B || keyCode == NKCODE_BUTTON_2;
+	} else {
+		return std::find(cancelKeys.begin(), cancelKeys.end(), (keycode_t)keyCode) != cancelKeys.end();
+	}
+}
+
+bool IsTabLeftKeyCode(int keyCode) {
+	if (tabLeftKeys.empty()) {
+		return keyCode == NKCODE_BUTTON_L1;
+	} else {
+		return std::find(tabLeftKeys.begin(), tabLeftKeys.end(), (keycode_t)keyCode) != tabLeftKeys.end();
+	}
+}
+
+bool IsTabRightKeyCode(int keyCode) {
+	if (tabRightKeys.empty()) {
+		return keyCode == NKCODE_BUTTON_R1;
+	} else {
+		return std::find(tabRightKeys.begin(), tabRightKeys.end(), (keycode_t)keyCode) != tabRightKeys.end();
+	}
 }
 
 void Clickable::Key(const KeyInput &key) {

--- a/ui/view.h
+++ b/ui/view.h
@@ -768,5 +768,7 @@ void EventTriggered(Event *e, EventParams params);
 void DispatchEvents();
 bool IsAcceptKeyCode(int keyCode);
 bool IsEscapeKeyCode(int keyCode);
+bool IsTabLeftKeyCode(int keyCode);
+bool IsTabRightKeyCode(int keyCode);
 
 }  // namespace

--- a/ui/viewgroup.cpp
+++ b/ui/viewgroup.cpp
@@ -975,9 +975,9 @@ void ChoiceStrip::HighlightChoice(unsigned int choice){
 
 void ChoiceStrip::Key(const KeyInput &input) {
 	if (input.flags & KEY_DOWN) {
-		if (input.keyCode == NKCODE_BUTTON_L1 && selected_ > 0) {
+		if (IsTabLeftKeyCode(input.keyCode) && selected_ > 0) {
 			SetSelection(selected_ - 1);
-		} else if (input.keyCode == NKCODE_BUTTON_R1 && selected_ < (int)views_.size() - 1) {
+		} else if (IsTabRightKeyCode(input.keyCode) && selected_ < (int)views_.size() - 1) {
 			SetSelection(selected_ + 1);
 		}
 	}


### PR DESCRIPTION
Basically, the same solution as confirm/cancel.

Also provides defaults for confirm/cancel in case the application does not set them (since I did this for L/R so that updating native should be clean.)

-[Unknown]
