### PR TITLE
Avoid leaking depth/stencil renderbuffers

### DIFF
--- a/gfx_es2/fbo.cpp
+++ b/gfx_es2/fbo.cpp
@@ -314,6 +314,8 @@ void fbo_destroy(FBO *fbo) {
 		glBindFramebuffer(GL_FRAMEBUFFER, 0);
 		glDeleteFramebuffers(1, &fbo->handle);
 		glDeleteRenderbuffers(1, &fbo->z_stencil_buffer);
+		glDeleteRenderbuffers(1, &fbo->z_buffer);
+		glDeleteRenderbuffers(1, &fbo->stencil_buffer);
 	} else {
 #ifndef USING_GLES2
 		glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, fbo->handle);


### PR DESCRIPTION
Only matters on devices without packed depth/stencil support, not sure how common this really is.

But pretty sure we ought to delete them if we ought to delete the packed one.

-[Unknown]
