### PR TITLE
Restore viewport natively in fbo_bind_as_render_target()

### DIFF
--- a/gfx_es2/fbo.cpp
+++ b/gfx_es2/fbo.cpp
@@ -278,10 +278,8 @@ void fbo_bind_as_render_target(FBO *fbo) {
 		glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, fbo->handle);
 #endif
 	}
-	// Adreno & Mali needs us to reset the viewport after switching render targets.
-	if ((gl_extensions.gpuVendor == GPU_VENDOR_ARM) || (gl_extensions.gpuVendor == GPU_VENDOR_ADRENO)) {
-		glstate.viewport.restore();
-	}
+	// Always restore viewport after render target binding
+	glstate.viewport.restore();
 }
 
 void fbo_bind_for_read(FBO *fbo) {


### PR DESCRIPTION
Then we can get rid of those elsewhere like in framebuffer.cpp
