### PR TITLE
Add encodeUnits() to utf8/utf16/sjis.

### DIFF
--- a/native.vcxproj
+++ b/native.vcxproj
@@ -287,6 +287,8 @@
     <ClInclude Include="util\random\perlin.h" />
     <ClInclude Include="util\random\rng.h" />
     <ClInclude Include="util\text\parsers.h" />
+    <ClInclude Include="util\text\shiftjis.h" />
+    <ClInclude Include="util\text\utf16.h" />
     <ClInclude Include="util\text\utf8.h" />
   </ItemGroup>
   <ItemGroup>

--- a/native.vcxproj.filters
+++ b/native.vcxproj.filters
@@ -338,6 +338,12 @@
     <ClInclude Include="math\fast\fast_matrix.h">
       <Filter>math\fast</Filter>
     </ClInclude>
+    <ClInclude Include="util\text\utf16.h">
+      <Filter>util</Filter>
+    </ClInclude>
+    <ClInclude Include="util\text\shiftjis.h">
+      <Filter>util</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="gfx\gl_debug_log.cpp">

--- a/util/text/shiftjis.h
+++ b/util/text/shiftjis.h
@@ -127,6 +127,13 @@ struct ShiftJIS {
 		return 2;
 	}
 
+	static int encodeUnits(uint32_t j) {
+		if ((j & ~0xFF) == 0) {
+			return 1;
+		}
+		return 2;
+	}
+
 private:
 	const char *c_;
 	int index_;

--- a/util/text/utf16.h
+++ b/util/text/utf16.h
@@ -42,7 +42,7 @@ public:
 		return len;
 	}
 
-	int byteIndex() const {
+	int shortIndex() const {
 		return index_;
 	}
 
@@ -54,6 +54,14 @@ public:
 			return 2;
 		} else {
 			*dest = UTF16_Swap<is_little>((uint16_t)u);
+			return 1;
+		}
+	}
+
+	static int encodeUnits(uint32_t u) {
+		if (u >= 0x10000) {
+			return 2;
+		} else {
 			return 1;
 		}
 	}

--- a/util/text/utf8.h
+++ b/util/text/utf8.h
@@ -44,6 +44,18 @@ public:
 	static int encode(char *dest, uint32_t ch) {
 		return u8_wc_toutf8(dest, ch);
 	}
+	static int encodeUnits(uint32_t ch) {
+		if (ch < 0x80) {
+			return 1;
+		} else if (ch < 0x800) {
+			return 2;
+		} else if (ch < 0x10000) {
+			return 3;
+		} else if (ch < 0x110000) {
+			return 4;
+		}
+		return 0;
+	}
 
 private:
 	const char *c_;


### PR DESCRIPTION
So that we know how many units (e.g. u16s) are needed to encode.

Also, don't call the index in utf-16 a byteIndex, since it's not.  Unfortunately this makes a cross dependency on updating ppsspp (hrydgard/ppsspp#6010).

-[Unknown]
