### PR TITLE
fbo_unbind() :  glBindFramebuffer(GL_READ_FRAMEBUFFER, 0)

### DIFF
--- a/gfx_es2/fbo.cpp
+++ b/gfx_es2/fbo.cpp
@@ -245,7 +245,16 @@ void fbo_unbind() {
 
 	CheckGLExtensions();
 	if (gl_extensions.FBO_ARB) {
-		glBindFramebuffer(GL_FRAMEBUFFER, 0);
+#ifndef USING_GLES2
+		if (true) {
+#else
+		if (gl_extensions.GLES3) {
+#endif
+			glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
+		}
+		else {
+			glBindFramebuffer(GL_FRAMEBUFFER, 0);
+		}
 	} else {
 #ifndef USING_GLES2
 		glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, 0);


### PR DESCRIPTION
To get rid of the follwing statments in framebuffer.cpp 

```
    if (gl_extensions.FBO_ARB) {
        glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
    }
```
