### PR TITLE
iOS: add GLES 3.0 support

### DIFF
--- a/gfx/gl_common.h
+++ b/gfx/gl_common.h
@@ -3,13 +3,10 @@
 
 #if defined(USING_GLES2)
 #ifdef IOS
-#ifdef MAY_HAVE_GLES3
+#define MAY_HAVE_GLES3 1
 #include <OpenGLES/ES3/gl.h>
 #include <OpenGLES/ES3/glext.h>
-#else
-#include <OpenGLES/ES2/gl.h>
-#include <OpenGLES/ES2/glext.h>
-#endif // MAY_HAVE_GLES3
+#include "../gfx_es2/gl3stub.h"
 #else
 #include <GLES2/gl2.h>
 #include <GLES2/gl2ext.h>

--- a/gfx_es2/gl3stub.c
+++ b/gfx_es2/gl3stub.c
@@ -14,13 +14,14 @@
  * limitations under the License.
  */
 
-#if !defined(IOS) && !defined(__SYMBIAN32__) && !defined(MEEGO_EDITION_HARMATTAN) && !defined(MAEMO)
+#if !defined(__SYMBIAN32__) && !defined(MEEGO_EDITION_HARMATTAN) && !defined(MAEMO)
 
 #include "../gfx/gl_common.h"
 
 #if defined(USING_GLES2)
 
 GLboolean gl3stubInit() {
+#if !defined(IOS)
     #define FIND_PROC(s) s = (void*)eglGetProcAddress(#s)
     FIND_PROC(glReadBuffer);
     FIND_PROC(glDrawRangeElements);
@@ -128,6 +129,7 @@ GLboolean gl3stubInit() {
     FIND_PROC(glGetInternalformativ);
     #undef FIND_PROC
 
+#endif // IOS
     if (!glReadBuffer ||
         !glDrawRangeElements ||
         !glTexImage3D ||
@@ -239,6 +241,8 @@ GLboolean gl3stubInit() {
     return GL_TRUE;
 }
 
+#if !defined(IOS)
+
 /* Function pointer definitions */
 GL_APICALL void           (* GL_APIENTRY glReadBuffer) (GLenum mode);
 GL_APICALL void           (* GL_APIENTRY glDrawRangeElements) (GLenum mode, GLuint start, GLuint end, GLsizei count, GLenum type, const GLvoid* indices);
@@ -345,5 +349,6 @@ GL_APICALL void           (* GL_APIENTRY glTexStorage2D) (GLenum target, GLsizei
 GL_APICALL void           (* GL_APIENTRY glTexStorage3D) (GLenum target, GLsizei levels, GLenum internalformat, GLsizei width, GLsizei height, GLsizei depth);
 GL_APICALL void           (* GL_APIENTRY glGetInternalformativ) (GLenum target, GLenum internalformat, GLenum pname, GLsizei bufSize, GLint* params);
 
+#endif // IOS
 #endif
 #endif

--- a/gfx_es2/gl3stub.h
+++ b/gfx_es2/gl3stub.h
@@ -46,6 +46,8 @@ extern "C" {
  * otherwise. */
 GLboolean gl3stubInit();
 
+#if !defined(IOS)
+    
 /*-------------------------------------------------------------------------
  * Data type definitions
  *-----------------------------------------------------------------------*/
@@ -482,6 +484,8 @@ extern GL_APICALL void           (* GL_APIENTRY glInvalidateSubFramebuffer) (GLe
 extern GL_APICALL void           (* GL_APIENTRY glTexStorage2D) (GLenum target, GLsizei levels, GLenum internalformat, GLsizei width, GLsizei height);
 extern GL_APICALL void           (* GL_APIENTRY glTexStorage3D) (GLenum target, GLsizei levels, GLenum internalformat, GLsizei width, GLsizei height, GLsizei depth);
 extern GL_APICALL void           (* GL_APIENTRY glGetInternalformativ) (GLenum target, GLenum internalformat, GLenum pname, GLsizei bufSize, GLint* params);
+    
+#endif   // IOS
 
 #ifdef __cplusplus
 }

--- a/gfx_es2/gl_state.cpp
+++ b/gfx_es2/gl_state.cpp
@@ -216,7 +216,7 @@ void CheckGLExtensions() {
 
 #ifdef USING_GLES2
 	gl_extensions.OES_texture_npot = strstr(extString, "OES_texture_npot") != 0;
-	gl_extensions.OES_packed_depth_stencil = strstr(extString, "GL_OES_packed_depth_stencil") != 0;
+	gl_extensions.OES_packed_depth_stencil = (strstr(extString, "GL_OES_packed_depth_stencil") != 0) || gl_extensions.GLES3;
 	gl_extensions.OES_depth24 = strstr(extString, "GL_OES_depth24") != 0;
 	gl_extensions.OES_depth_texture = strstr(extString, "GL_OES_depth_texture") != 0;
 	gl_extensions.OES_mapbuffer = strstr(extString, "GL_OES_mapbuffer") != 0;


### PR DESCRIPTION
Tested on iPhone 4S (iOS 7.0.4, GLES 2.0, Jailbreak) and iPad Air (iOS 7.0.4, GLES 3.0, Without jail).
