### PR TITLE
Add a new Choice subclass which lets the UI display a value in addition to the title, similar to other controls.

### DIFF
--- a/ui/ui_screen.cpp
+++ b/ui/ui_screen.cpp
@@ -450,4 +450,19 @@ void TextEditPopupScreen::OnCompleted(DialogResult result) {
 	}
 }
 
+void ChoiceWithValueDisplay::Draw(UIContext &dc) {
+	Style style = dc.theme->itemStyle;
+	std::ostringstream valueText;
+	Choice::Draw(dc);
+	dc.SetFontStyle(dc.theme->uiFont);
+
+	if (sValue_ != nullptr) {
+		valueText << *sValue_;
+	} else if (iValue_ != nullptr) {
+		valueText << *iValue_;
+	}
+
+	dc.DrawText(valueText.str().c_str(), bounds_.x2() - 12, bounds_.centerY(), style.fgColor, ALIGN_RIGHT | ALIGN_VCENTER);
+}
+
 }  // namespace UI

--- a/ui/ui_screen.h
+++ b/ui/ui_screen.h
@@ -266,4 +266,19 @@ private:
 	std::string defaultText_;
 };
 
+class ChoiceWithValueDisplay : public UI::Choice {
+public:
+	ChoiceWithValueDisplay(int *value, const std::string &text, LayoutParams *layoutParams = 0)
+		: Choice(text, layoutParams), iValue_(value) { sValue_ = nullptr; }
+
+	ChoiceWithValueDisplay(std::string *value, const std::string &text, LayoutParams *layoutParams = 0)
+		: Choice(text, layoutParams), sValue_(value) { iValue_ = nullptr; }
+
+	void Draw(UIContext &dc);
+
+private:
+	int *iValue_;
+	std::string *sValue_;
+};
+
 }  // namespace UI


### PR DESCRIPTION
Intended usage:
![Screenshot 01](http://i.minus.com/ibqgRut9a8siYm.jpg)

Looks exactly the same as it currently does in PPSSPP's master branch, but it's handy for certain situations like the MAC address randomiser (so that touching it will simply update the string to the right), and the postprocessing shaders custom choice event.

To be honest, I couldn't think of a better class name, so if you can think of one better than ChoiceWithValueDisplay, I'm all ears.
