### PR TITLE
Qt: Fix double ampersands in text.

### DIFF
--- a/gfx_es2/draw_text.cpp
+++ b/gfx_es2/draw_text.cpp
@@ -284,7 +284,7 @@ void TextDrawer::DrawString(DrawBuffer &target, const char *str, float x, float 
 		painter.begin(&image);
 		painter.setFont(*font);
 		painter.setPen(color);
-		painter.drawText(image.rect(), Qt::AlignTop | Qt::AlignLeft, QString::fromUtf8(str));
+		painter.drawText(image.rect(), Qt::AlignTop | Qt::AlignLeft, QString::fromUtf8(str).replace("&&", "&"));
 		painter.end();
 
 		entry = new TextStringEntry();


### PR DESCRIPTION
For some reason there are double ampersands appearing when Qt displays the text. Although I don't see how other platforms remove it.
