### PR TITLE
add ability to create opaque FBO objects from native opengl FBOs

### DIFF
--- a/gfx_es2/fbo.h
+++ b/gfx_es2/fbo.h
@@ -4,6 +4,8 @@
 // Very C-ish API because that's what I felt like, and it's cool to completely
 // hide the data from callers...
 
+#include "gfx/gl_common.h"
+
 struct FBO;
 
 
@@ -23,6 +25,10 @@ enum FBOColorDepth {
 
 // On some hardware, you might get a 24-bit depth buffer even though you only wanted a 16-bit one.
 FBO *fbo_create(int width, int height, int num_color_textures, bool z_stencil, FBOColorDepth colorDepth = FBO_8888);
+
+// Create an opaque FBO from a native GL FBO, optionally reusing an existing FBO structure.
+// Useful for overriding the backbuffer FBO that is generated outside of this wrapper.
+FBO *fbo_create_from_native_fbo(GLuint native_fbo, FBO *fbo = NULL);
 
 // These functions should be self explanatory.
 void fbo_bind_as_render_target(FBO *fbo);


### PR DESCRIPTION
I need the ability to pass in a FBO generated from outside this interface for a project as a new backbuffer. This adds a simple function to create (or optionally reuse) an opaque FBO structure from a native FBO. Since it only adds the FBO object, it's only really useful for setting the backbuffer.
