### PR TITLE
d3d: fix scissoring by using top=actual top

### DIFF
--- a/thin3d/thin3d_gl.cpp
+++ b/thin3d/thin3d_gl.cpp
@@ -268,7 +268,7 @@ public:
 	}
 
 	void SetScissorRect(int left, int top, int width, int height) override {
-		glstate.scissorRect.set(left, top, width, height);
+		glstate.scissorRect.set(left, targetHeight_ - (top + height), width, height);
 	}
 
 	void SetViewports(int count, T3DViewport *viewports) override {

--- a/ui/ui_context.cpp
+++ b/ui/ui_context.cpp
@@ -100,10 +100,9 @@ void UIContext::ActivateTopScissor() {
 		const Bounds &bounds = scissorStack_.back();
 		float scale = 1.0f / g_dpi_scale;
 		int x = scale * bounds.x;
-		int y = scale * (dp_yres - bounds.y2());
+		int y = scale * bounds.y;
 		int w = scale * bounds.w;
 		int h = scale * bounds.h;
-
 		thin3d_->SetScissorRect(x, y, w, h);
 		thin3d_->SetScissorEnabled(true);
 	} else {


### PR DESCRIPTION
Pretty straightforward.

-[Unknown]
