### PR TITLE
Cache bound fbos, allow unbinding only read

### DIFF
--- a/gfx_es2/fbo.h
+++ b/gfx_es2/fbo.h
@@ -36,6 +36,8 @@ void fbo_bind_as_render_target(FBO *fbo);
 void fbo_bind_color_as_texture(FBO *fbo, int color);
 void fbo_bind_for_read(FBO *fbo);
 void fbo_unbind();
+void fbo_unbind_render_target();
+void fbo_unbind_read();
 void fbo_destroy(FBO *fbo);
 void fbo_get_dimensions(FBO *fbo, int *w, int *h);
 


### PR DESCRIPTION
This maintains the currently bound fbos, similar to glstate.  So long as these funcs are used, it can prevent duplicate binds.

Binding the same buffer twice comes with a performance penalty.  In one case (Tales of Phantasia X with a "hot" town with tons of intra-buffer copies), this alone improved perf by 10-20%.  For normal usage it's much much smaller.

Obsoletes, or fixes #212, since it adds a way to unbind the read buffer only.

-[Unknown]
