### PR TITLE
base: Allow building when not using X11 on a FBDEV based system

### DIFF
--- a/base/PCMain.cpp
+++ b/base/PCMain.cpp
@@ -59,16 +59,24 @@ static int g_DesktopHeight = 0;
 
 #if defined(USING_EGL)
 #include "EGL/egl.h"
+
+#if !defined(USING_FBDEV)
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
+#endif
+
 #include "SDL_syswm.h"
 #include "math.h"
 
-static EGLDisplay          g_eglDisplay    = NULL;
-static EGLContext          g_eglContext    = NULL;
-static EGLSurface          g_eglSurface    = NULL;
-static Display*            g_Display       = NULL;
-static NativeWindowType    g_Window        = (NativeWindowType)NULL;
+static EGLDisplay               g_eglDisplay    = NULL;
+static EGLContext               g_eglContext    = NULL;
+static EGLSurface               g_eglSurface    = NULL;
+#ifdef USING_FBDEV
+static EGLNativeDisplayType     g_Display       = NULL;
+#else
+static Display*                 g_Display       = NULL;
+#endif
+static NativeWindowType         g_Window        = (NativeWindowType)NULL;
 
 int8_t CheckEGLErrors(const std::string& file, uint16_t line) {
 	EGLenum error;
@@ -144,13 +152,15 @@ int8_t EGL_Init() {
 	g_eglContext = eglCreateContext(g_eglDisplay, g_eglConfig, NULL, attributes );
 	if (g_eglContext == EGL_NO_CONTEXT) EGL_ERROR("Unable to create GLES context!", true);
 
-	// Get the SDL window handle
+#if !defined(USING_FBDEV)
+	//Get the SDL window handle
 	SDL_SysWMinfo sysInfo; //Will hold our Window information
 	SDL_VERSION(&sysInfo.version); //Set SDL version
 	if (SDL_GetWMInfo(&sysInfo) <= 0) {
 		printf("EGL ERROR: Unable to get SDL window handle: %s\n", SDL_GetError());
 		return 1;
 	}
+#endif
 
 #ifdef USING_FBDEV
 	g_Window = (NativeWindowType)NULL;
@@ -180,7 +190,9 @@ void EGL_Close() {
 		g_eglDisplay = NULL;
 	}
 	if (g_Display != NULL) {
+#if !defined(USING_FBDEV)
 		XCloseDisplay(g_Display);
+#endif
 		g_Display = NULL;
 	}
 	g_eglSurface = NULL;


### PR DESCRIPTION
- Currently building base will fail on non X11 based systems due to
  inclusion of X11 headers and some calls to X11 functions.
- Portions of the code currently attempts to avoid calling X11 functions
  when fbdev is used. This patch adds additional checks to avoid X11 calls.

Signed-off-by: Franklin S Cooper Jr fcooper27@gmail.com
