### PR TITLE
Compatibility ndk r9d armeabi-v7a-hard APP_ABI building.

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -109,7 +109,8 @@ LOCAL_C_INCLUDES := $(LOCAL_PATH)/ext $(LOCAL_PATH)/ext/libzip
 
 #Portable native and separate code on android in future is easy you needs add files 
 #by ($(target_arch_ABI),arquitecture (armeabi-v7a , armeabi , x86 , MIPS)
-ifeq ($(TARGET_ARCH_ABI), armeabi-v7a)
+# ifeq ($(TARGET_ARCH_ABI),armeabi-v7a)
+ifeq ($(findstring armeabi-v7a,$(TARGET_ARCH_ABI)),armeabi-v7a)
 LOCAL_CFLAGS := $(LOCAL_CFLAGS) -DARM -DARMEABI_V7A
 LOCAL_SRC_FILES := $(LOCAL_SRC_FILES) \
     math/fast/fast_matrix_neon.S.neon \


### PR DESCRIPTION
Fix APP_ABI=armeabi-v7a-hard ndk building problem.

I also create a pull request for ppsspp main rep.
