### PR TITLE
Correctly append to a fixed buffer while logging

### DIFF
--- a/base/logging.h
+++ b/base/logging.h
@@ -83,15 +83,15 @@ void OutputDebugStringUTF8(const char *p);
 #ifdef _WIN32
 
 #ifdef _DEBUG
-#define DLOG(...) {char temp[512]; char *p = temp; p += sprintf(p, "D: %s:%i: ", __FILE__, __LINE__); p += snprintf(p, 450, "D: " __VA_ARGS__); p += sprintf(p, "\n"); OutputDebugStringUTF8(temp);}
+#define DLOG(...) {char temp[512]; char *p = temp; p += sprintf(p, "D: %s:%i: ", __FILE__, __LINE__); p += snprintf(p, 450, "D: " __VA_ARGS__); if (p > temp + 450) p = temp + 450; p += sprintf(p, "\n"); OutputDebugStringUTF8(temp);}
 #else
 #define DLOG(...)
 #endif
 
-#define ILOG(...) {char temp[512]; char *p = temp; p += sprintf(p, "I: %s:%i: ", __FILE__, __LINE__); p += snprintf(p, 450, "I: " __VA_ARGS__); p += sprintf(p, "\n"); OutputDebugStringUTF8(temp);}
-#define WLOG(...) {char temp[512]; char *p = temp; p += sprintf(p, "W: %s:%i: ", __FILE__, __LINE__); p += snprintf(p, 450, "W: " __VA_ARGS__); p += sprintf(p, "\n"); OutputDebugStringUTF8(temp);}
-#define ELOG(...) {char temp[512]; char *p = temp; p += sprintf(p, "E: %s:%i: ", __FILE__, __LINE__); p += snprintf(p, 450, "E: " __VA_ARGS__); p += sprintf(p, "\n"); OutputDebugStringUTF8(temp);}
-#define FLOG(...) {char temp[512]; char *p = temp; p += sprintf(p, "F: %s:%i: ", __FILE__, __LINE__); p += snprintf(p, 450, "F: " __VA_ARGS__); p += sprintf(p, "\n"); OutputDebugStringUTF8(temp); Crash();}
+#define ILOG(...) {char temp[512]; char *p = temp; p += sprintf(p, "I: %s:%i: ", __FILE__, __LINE__); p += snprintf(p, 450, "I: " __VA_ARGS__); if (p > temp + 450) p = temp + 450; p += sprintf(p, "\n"); OutputDebugStringUTF8(temp);}
+#define WLOG(...) {char temp[512]; char *p = temp; p += sprintf(p, "W: %s:%i: ", __FILE__, __LINE__); p += snprintf(p, 450, "W: " __VA_ARGS__); if (p > temp + 450) p = temp + 450; p += sprintf(p, "\n"); OutputDebugStringUTF8(temp);}
+#define ELOG(...) {char temp[512]; char *p = temp; p += sprintf(p, "E: %s:%i: ", __FILE__, __LINE__); p += snprintf(p, 450, "E: " __VA_ARGS__); if (p > temp + 450) p = temp + 450; p += sprintf(p, "\n"); OutputDebugStringUTF8(temp);}
+#define FLOG(...) {char temp[512]; char *p = temp; p += sprintf(p, "F: %s:%i: ", __FILE__, __LINE__); p += snprintf(p, 450, "F: " __VA_ARGS__); if (p > temp + 450) p = temp + 450; p += sprintf(p, "\n"); OutputDebugStringUTF8(temp); Crash();}
 
 // TODO: Win32 version using OutputDebugString
 #else


### PR DESCRIPTION
I no longer like snprintf().  I didn't realize it returns the size that _would have been written_, instead of the size that _was actually written_ (as gcc used to do before c99.)  That's terrible.

Will take care of hrydgard/ppsspp#7050 once merged and native updated.

-[Unknown]
