### PR TITLE
Fix a memory leak on error condition

### DIFF
--- a/file/chunk_file.cpp
+++ b/file/chunk_file.cpp
@@ -48,7 +48,7 @@ ChunkFile::ChunkFile(const uint8_t *read_data, int data_size) {
 }
 
 ChunkFile::~ChunkFile() {
-	if (fastMode && data)
+	if (fastMode)
 		delete [] data;
 	else
 		file.close();

--- a/file/zip_read.h
+++ b/file/zip_read.h
@@ -64,7 +64,8 @@ private:
 class DirectoryAssetReader : public AssetReader {
 public:
 	DirectoryAssetReader(const char *path) {
-		strcpy(path_, path);
+		strncpy(path_, path, ARRAY_SIZE(path_));
+		path_[ARRAY_SIZE(path_) - 1] = '\0';
 	}
 	// use delete[]
 	virtual uint8_t *ReadAsset(const char *path, size_t *size);

--- a/gfx_es2/draw_text.cpp
+++ b/gfx_es2/draw_text.cpp
@@ -70,6 +70,8 @@ TextDrawer::~TextDrawer() {
 
 	DeleteObject(ctx_->hbmBitmap);
 	DeleteDC(ctx_->hDC);
+
+	delete ctx_;
 }
 
 uint32_t TextDrawer::SetFont(const char *fontName, int size, int flags) {

--- a/gfx_es2/gl_state.cpp
+++ b/gfx_es2/gl_state.cpp
@@ -194,6 +194,7 @@ void CheckGLExtensions() {
 		g_all_gl_extensions = extString;
 	} else {
 		g_all_gl_extensions = "";
+		extString = "";
 	}
 
 #ifdef WIN32
@@ -342,7 +343,7 @@ void CheckGLExtensions() {
 	gl_extensions.FBO_EXT = false;
 	gl_extensions.PBO_ARB = true;
 	gl_extensions.PBO_NV = true;
-	if (extString) {
+	if (strlen(extString) != 0) {
 		gl_extensions.FBO_ARB = strstr(extString, "GL_ARB_framebuffer_object") != 0;
 		gl_extensions.FBO_EXT = strstr(extString, "GL_EXT_framebuffer_object") != 0;
 		gl_extensions.PBO_ARB = strstr(extString, "GL_ARB_pixel_buffer_object") != 0;


### PR DESCRIPTION
Might as well not leak.  Wish I could just use `std::unique_ptr<char[]>`.

-[Unknown]