### PR TITLE
Resize in Qt like in other backends

### DIFF
--- a/base/QtMain.h
+++ b/base/QtMain.h
@@ -80,13 +80,9 @@ signals:
 protected:
 	void resizeEvent(QResizeEvent * e)
 	{
-		pixel_xres = e->size().width();
-		pixel_yres = e->size().height();
-		dp_xres = pixel_xres * g_dpi_scale;
-		dp_yres = pixel_yres * g_dpi_scale;
+		UpdateScreenScale(e->size().width(), e->size().height());
 		PSP_CoreParameter().pixelWidth = pixel_xres;
 		PSP_CoreParameter().pixelHeight = pixel_yres;
-		UpdateScreenScale(pixel_xres, pixel_yres);
 	}
 
 	void timerEvent(QTimerEvent *) {


### PR DESCRIPTION
Should fix switching to fullscren and probably also resizing in general.

`UpdateScreenScale()` checks if the values changed, so forcing them beforehand (and basically doing its job) only interferes with it.

Should help hrydgard/ppsspp#7351.

-[Unknown]