### PR TITLE
You need this if you don't want to install libglew-dev dependence.

### DIFF
--- a/ext/glew/GL/glxew.h
+++ b/ext/glew/GL/glxew.h
@@ -98,7 +98,7 @@
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
 #include <X11/Xmd.h>
-#include <GL/glew.h>
+#include "glew.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/ext/glew/glew.c
+++ b/ext/glew/glew.c
@@ -30,12 +30,12 @@
 ** THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include <GL/glew.h>
+#include "GL/glew.h"
 
 #if defined(_WIN32)
 #  include <GL/wglew.h>
 #elif !defined(__ANDROID__) && !defined(__native_client__) && !defined(__HAIKU__) && (!defined(__APPLE__) || defined(GLEW_APPLE_GLX))
-#  include <GL/glxew.h>
+#  include "GL/glxew.h"
 #endif
 
 #include <stddef.h>  /* For size_t */

--- a/ext/glew/glewinfo.c
+++ b/ext/glew/glewinfo.c
@@ -33,11 +33,11 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <GL/glew.h>
+#include "GL/glew.h"
 #if defined(_WIN32)
 #include <GL/wglew.h>
 #elif !defined(__APPLE__) && !defined(__HAIKU__) || defined(GLEW_APPLE_GLX)
-#include <GL/glxew.h>
+#include "GL/glxew.h"
 #endif
 
 #ifdef GLEW_REGAL

--- a/ext/glew/visualinfo.c
+++ b/ext/glew/visualinfo.c
@@ -33,13 +33,13 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <GL/glew.h>
+#include "GL/glew.h"
 #if defined(_WIN32)
 #include <GL/wglew.h>
 #elif defined(__APPLE__) && !defined(GLEW_APPLE_GLX)
 #include <AGL/agl.h>
 #elif !defined(__HAIKU__)
-#include <GL/glxew.h>
+#include "GL/glxew.h"
 #endif
 
 #ifdef GLEW_MX

--- a/gfx/gl_common.h
+++ b/gfx/gl_common.h
@@ -11,7 +11,7 @@
 typedef char GLchar;
 #define GL_BGRA_EXT 0x80E1
 #else // OpenGL
-#include <GL/glew.h>
+#include "GL/glew.h"
 #if defined(__APPLE__)
 #include <OpenGL/gl.h>
 #else


### PR DESCRIPTION
I had problem in Ubuntu at least, I had to install libglew-dev without this patch.