### PR TITLE
Miscellaneous portability fixes

### DIFF
--- a/base/basictypes.h
+++ b/base/basictypes.h
@@ -87,7 +87,7 @@ inline uint64 swap64(uint64 _data) {return ((uint64)swap32(_data) << 32) | swap3
 inline uint16 swap16(uint16 _data) {return bswap_16(_data);}
 inline uint32 swap32(uint32 _data) {return bswap_32(_data);}
 inline uint64 swap64(uint64 _data) {return bswap_64(_data);}
-#elif defined(__FreeBSD__)
+#elif defined(__DragonFly__) || defined(__FreeBSD__)
 #include <sys/endian.h>
 inline uint16 swap16(uint16 _data) {return bswap16(_data);}
 inline uint32 swap32(uint32 _data) {return bswap32(_data);}

--- a/ext/cityhash/city.cpp
+++ b/ext/cityhash/city.cpp
@@ -68,12 +68,12 @@ static uint32 UNALIGNED_LOAD32(const char *p) {
 #define bswap_32(x) BSWAP_32(x)
 #define bswap_64(x) BSWAP_64(x)
 
-#elif defined(__FreeBSD__)
+#elif defined(__DragonFly__) || defined(__FreeBSD__)
 #include <sys/endian.h>
 #define bswap_32(x) bswap32(x)
 #define bswap_64(x) bswap64(x)
 
-#elif defined(__OpenBSD__)
+#elif defined(__Bitrig__) || defined(__OpenBSD__)
 #include <sys/types.h>
 #define bswap_32(x) swap32(x)
 #define bswap_64(x) swap64(x)

--- a/ext/stb_vorbis/stb_vorbis.c
+++ b/ext/stb_vorbis/stb_vorbis.c
@@ -15,7 +15,8 @@
 #pragma warning (disable:4996)
 #pragma warning (disable:4244)
 #include <malloc.h>
-#elif !defined(__SYMBIAN32__)
+#elif !defined(__SYMBIAN32__) && !defined(__Bitrig__) && !defined(__DragonFly__) && \
+      !defined(__FreeBSD__) && !defined(__NetBSD__) && !defined(__OpenBSD__)
 #include <alloca.h>
 #endif
 

--- a/file/file_util.cpp
+++ b/file/file_util.cpp
@@ -25,7 +25,7 @@
 #include "file/file_util.h"
 #include "util/text/utf8.h"
 
-#if defined(__FreeBSD__) || defined(__APPLE__)
+#if !defined(__linux__) && !defined(__SYMBIAN32__)
 #define stat64 stat
 #endif
 

--- a/net/http_client.h
+++ b/net/http_client.h
@@ -11,11 +11,8 @@
 #define NOMINMAX
 #include <winsock2.h>
 #else
-#if defined(__FreeBSD__) || defined(__SYMBIAN32__)
 #include <netinet/in.h>
-#else
 #include <arpa/inet.h>
-#endif
 #include <sys/socket.h>
 #include <netdb.h>
 #endif

--- a/net/http_headers.cpp
+++ b/net/http_headers.cpp
@@ -1,11 +1,5 @@
 #include "net/http_headers.h"
 
-#ifdef _WIN32
-
-#include <winsock2.h>   // for timeval
-
-#endif
-
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -132,11 +126,6 @@ int RequestHeader::ParseHttpHeader(const char *buffer) {
 }
 
 void RequestHeader::ParseHeaders(int fd) {
-  // Get the request, with a timeout.
-  struct ::timeval tv;
-  tv.tv_sec = 5;
-  tv.tv_usec = 0;
-
   int line_count = 0;
   // Loop through request headers.
   while (true) {

--- a/net/http_server.cpp
+++ b/net/http_server.cpp
@@ -11,6 +11,7 @@
 #include <sys/socket.h>       /*  socket definitions        */
 #include <sys/types.h>        /*  socket types              */
 #include <sys/wait.h>         /*  for waitpid()             */
+#include <netinet/in.h>       /*  struct sockaddr_in        */
 #include <arpa/inet.h>        /*  inet (3) funtions         */
 #include <unistd.h>           /*  misc. UNIX functions      */
 

--- a/net/resolve.cpp
+++ b/net/resolve.cpp
@@ -14,11 +14,8 @@
 #undef min
 #undef max
 #else
-#if defined(__FreeBSD__)
 #include <netinet/in.h>
-#else
 #include <arpa/inet.h>
-#endif
 #include <netdb.h>
 #include <sys/socket.h>
 #include <unistd.h>


### PR DESCRIPTION
I've made a [FreeBSD port](https://freshports.org/emulators/ppsspp) for ppssp with other four BSDs in mind. Our cluster (beefy* and muscles) build logs should be available in a few days.

The risk of the changes in the pull is as follow:

- 7af88bf, b9b02eb cannot break build except for typos
- babb503 unlikely to break build given ppssp already uses `<netinet/in.h>`
- 4593b22 unlikely to break build unless `<winsock2.h>` is still used by something else
- bad9806 may affect runtime on unknown platforms (Solaris?) if not careful
