### PR TITLE
VSync control for non-win32 platforms

### DIFF
--- a/gfx_es2/gl_state.cpp
+++ b/gfx_es2/gl_state.cpp
@@ -5,7 +5,11 @@
 #include "gl_state.h"
 
 #ifdef _WIN32
-#include "GL/wglew.h"
+#  include "GL/wglew.h"
+#elif !defined(__ANDROID__) && !defined(__native_client__) && !defined(__HAIKU__) && (!defined(__APPLE__) || defined(GLEW_APPLE_GLX))
+#  include "GL/glxew.h"
+#elif defined(__APPLE__) && !defined(USING_GLES2)
+#  include "OpenGL/OpenGL.h"
 #endif
 
 #if defined(USING_GLES2)
@@ -400,5 +404,16 @@ void OpenGLState::SetVSyncInterval(int interval) {
 #ifdef _WIN32
 	if (wglSwapIntervalEXT)
 		wglSwapIntervalEXT(interval);
+#elif !defined(__ANDROID__) && !defined(__native_client__) && !defined(__HAIKU__) && (!defined(__APPLE__) || defined(GLEW_APPLE_GLX))
+	if (glXGetCurrentDisplay && glXGetCurrentDrawable && glXSwapIntervalEXT) {
+		Display *dpy = glXGetCurrentDisplay();
+		GLXDrawable drawable = glXGetCurrentDrawable();
+
+		if (drawable) {
+			glXSwapIntervalEXT(dpy, drawable, interval);
+		}
+	}
+#elif defined(__APPLE__) && !defined(USING_GLES2)
+	CGLSetParameter(CGLGetCurrentContext(), kCGLCPSwapInterval, &interval);
 #endif
 }

--- a/gfx_es2/gl_state.h
+++ b/gfx_es2/gl_state.h
@@ -289,7 +289,6 @@ public:
 	STATEBIND(glBindBuffer, GL_ARRAY_BUFFER) arrayBuffer;
 	STATEBIND(glBindBuffer, GL_ELEMENT_ARRAY_BUFFER) elementArrayBuffer;
 
-	// Only works on Win32, all other platforms are "force-vsync"
 	void SetVSyncInterval(int interval);  // one of the above VSYNC, or a higher number for multi-frame waits (could be useful for 30hz games)
 };
 


### PR DESCRIPTION
Without turning vsync off, game is limited at 60fps even with alternate speed enabled.