### PR TITLE
Retain focus after popup choice selection

### DIFF
--- a/ui/ui_screen.cpp
+++ b/ui/ui_screen.cpp
@@ -255,6 +255,8 @@ UI::EventReturn ListPopupScreen::OnListChoice(UI::EventParams &e) {
 namespace UI {
 
 UI::EventReturn PopupMultiChoice::HandleClick(UI::EventParams &e) {
+	restoreFocus_ = HasFocus();
+
 	std::vector<std::string> choices;
 	for (int i = 0; i < numChoices_; i++) {
 		choices.push_back(category_ ? category_->T(choices_[i]) : choices_[i]);
@@ -288,6 +290,10 @@ void PopupMultiChoice::ChoiceCallback(int num) {
 		e.v = this;
 		e.a = num;
 		OnChoice.Trigger(e);
+
+		if (restoreFocus_) {
+			SetFocusedView(this);
+		}
 	}
 }
 

--- a/ui/ui_screen.cpp
+++ b/ui/ui_screen.cpp
@@ -329,6 +329,8 @@ PopupSliderChoiceFloat::PopupSliderChoiceFloat(float *value, float minValue, flo
 }
 
 EventReturn PopupSliderChoice::HandleClick(EventParams &e) {
+	restoreFocus_ = HasFocus();
+
 	SliderPopupScreen *popupScreen = new SliderPopupScreen(value_, minValue_, maxValue_, text_, step_);
 	popupScreen->OnChange.Handle(this, &PopupSliderChoice::HandleChange);
 	screenManager_->push(popupScreen);
@@ -338,6 +340,10 @@ EventReturn PopupSliderChoice::HandleClick(EventParams &e) {
 EventReturn PopupSliderChoice::HandleChange(EventParams &e) {
 	e.v = this;
 	OnChange.Trigger(e);
+
+	if (restoreFocus_) {
+		SetFocusedView(this);
+	}
 	return EVENT_DONE;
 }
 
@@ -354,6 +360,8 @@ void PopupSliderChoice::Draw(UIContext &dc) {
 }
 
 EventReturn PopupSliderChoiceFloat::HandleClick(EventParams &e) {
+	restoreFocus_ = HasFocus();
+
 	SliderFloatPopupScreen *popupScreen = new SliderFloatPopupScreen(value_, minValue_, maxValue_, text_, step_);
 	popupScreen->OnChange.Handle(this, &PopupSliderChoiceFloat::HandleChange);
 	screenManager_->push(popupScreen);
@@ -363,6 +371,10 @@ EventReturn PopupSliderChoiceFloat::HandleClick(EventParams &e) {
 EventReturn PopupSliderChoiceFloat::HandleChange(EventParams &e) {
 	e.v = this;
 	OnChange.Trigger(e);
+
+	if (restoreFocus_) {
+		SetFocusedView(this);
+	}
 	return EVENT_DONE;
 }
 
@@ -453,6 +465,8 @@ PopupTextInputChoice::PopupTextInputChoice(std::string *value, const std::string
 }
 
 EventReturn PopupTextInputChoice::HandleClick(EventParams &e) {
+	restoreFocus_ = HasFocus();
+
 	TextEditPopupScreen *popupScreen = new TextEditPopupScreen(value_, placeHolder_, text_, maxLen_);
 	popupScreen->OnChange.Handle(this, &PopupTextInputChoice::HandleChange);
 	screenManager_->push(popupScreen);
@@ -472,6 +486,10 @@ void PopupTextInputChoice::Draw(UIContext &dc) {
 EventReturn PopupTextInputChoice::HandleChange(EventParams &e) {
 	e.v = this;
 	OnChange.Trigger(e);
+
+	if (restoreFocus_) {
+		SetFocusedView(this);
+	}
 	return EVENT_DONE;
 }
 

--- a/ui/ui_screen.h
+++ b/ui/ui_screen.h
@@ -218,6 +218,7 @@ private:
 	I18NCategory *category_;
 	ScreenManager *screenManager_;
 	std::string valueText_;
+	bool restoreFocus_;
 };
 
 

--- a/ui/ui_screen.h
+++ b/ui/ui_screen.h
@@ -240,6 +240,7 @@ private:
 	int maxValue_;
 	int step_;
 	ScreenManager *screenManager_;
+	bool restoreFocus_;
 };
 
 class PopupSliderChoiceFloat : public Choice {
@@ -259,6 +260,7 @@ private:
 	float maxValue_;
 	float step_;
 	ScreenManager *screenManager_;
+	bool restoreFocus_;
 };
 
 class PopupTextInputChoice: public Choice {
@@ -277,6 +279,7 @@ private:
 	std::string placeHolder_;
 	std::string defaultText_;
 	int maxLen_;
+	bool restoreFocus_;
 };
 
 class ChoiceWithValueDisplay : public UI::Choice {


### PR DESCRIPTION
When using a controller or keyboard, before, if you went through the options and changed some settings, you'd end up losing focus and starting at the top of the screen again.

This retains it for a better experience.

-[Unknown]