### PR TITLE
Marquee popup headers and highlight focused TextViews

### DIFF
--- a/ui/view.cpp
+++ b/ui/view.cpp
@@ -622,6 +622,12 @@ void TextView::Draw(UIContext &dc) {
 		dc.Flush();
 		dc.PushScissor(clipRect);
 	}
+	// In case it's been made focusable.
+	if (HasFocus()) {
+		UI::Style style = dc.theme->itemFocusedStyle;
+		style.background.color &= 0x7fffffff;
+		dc.FillRect(style.background, bounds_);
+	}
 	dc.SetFontStyle(small_ ? dc.theme->uiFontSmall : dc.theme->uiFont);
 	if (shadow_) {
 		uint32_t shadowColor = 0x80000000;

--- a/ui/view.cpp
+++ b/ui/view.cpp
@@ -3,6 +3,7 @@
 
 #include "base/mutex.h"
 #include "base/stringutil.h"
+#include "base/timeutil.h"
 #include "input/input_state.h"
 #include "input/keycodes.h"
 #include "gfx_es2/draw_buffer.h"
@@ -441,9 +442,31 @@ void ItemHeader::Draw(UIContext &dc) {
 }
 
 void PopupHeader::Draw(UIContext &dc) {
+	const float paddingHorizontal = 12;
+	const float availableWidth = bounds_.w - paddingHorizontal * 2;
+
+	float tw, th;
 	dc.SetFontStyle(dc.theme->uiFont);
-	dc.DrawText(text_.c_str(), bounds_.x + 12, bounds_.centerY(), dc.theme->popupTitle.fgColor, ALIGN_LEFT | ALIGN_VCENTER);
+	dc.MeasureText(dc.GetFontStyle(), text_.c_str(), &tw, &th, 0);
+
+	float sineWidth = std::max(0.0f, (tw - availableWidth)) / 2.0f;
+
+	float tx = paddingHorizontal;
+	if (availableWidth < tw) {
+		float overageRatio = 1.5f * availableWidth * 1.0f / tw;
+		tx -= (1.0f + sin(time_now_d() * overageRatio)) * sineWidth;
+		Bounds tb = bounds_;
+		tb.x = bounds_.x + paddingHorizontal;
+		tb.w = bounds_.w - paddingHorizontal * 2;
+		dc.PushScissor(tb);
+	}
+
+	dc.DrawText(text_.c_str(), bounds_.x + tx, bounds_.centerY(), dc.theme->popupTitle.fgColor, ALIGN_LEFT | ALIGN_VCENTER);
 	dc.Draw()->DrawImageStretch(dc.theme->whiteImage, bounds_.x, bounds_.y2()-2, bounds_.x2(), bounds_.y2(), dc.theme->popupTitle.fgColor);
+
+	if (availableWidth < tw) {
+		dc.PopScissor();
+	}
 }
 
 void CheckBox::Toggle(){

--- a/ui/view.h
+++ b/ui/view.h
@@ -593,7 +593,7 @@ public:
 
 	void Draw(UIContext &dc) override;
 
-	// These are focusable so that long lists of them can be keybaord scrolled.
+	// These are focusable so that long lists of them can be keyboard scrolled.
 	bool CanBeFocused() const override { return true; }
 
 private:


### PR DESCRIPTION
These are sorta separate, but mostly on the same topic of UI.

 * Without the highlight, scrolling a list of focusable TextViews (e.g. sysinfo) is confusing.  It sometimes scrolls, but not always, and you don't realize it depends on which item you've "highlighted".

 * Long popup header titles (such as with savedata) were overflowing, now they show with a marquee effect.

-[Unknown]