### PR TITLE
Linux controller fix

### DIFF
--- a/input/input_state.cpp
+++ b/input/input_state.cpp
@@ -51,10 +51,29 @@ int MapPadButtonFixed(int keycode) {
 	}
 }
 
+std::vector<KeyDef> dpadKeys;
 std::vector<KeyDef> confirmKeys;
 std::vector<KeyDef> cancelKeys;
 std::vector<KeyDef> tabLeftKeys;
 std::vector<KeyDef> tabRightKeys;
+
+static void AppendKeys(std::vector<KeyDef> &keys, const std::vector<KeyDef> &newKeys) {
+	for (auto iter = newKeys.begin(); iter != newKeys.end(); ++iter) {
+		keys.push_back(*iter);
+	}
+}
+
+void SetDPadKeys(const std::vector<KeyDef> &leftKey, const std::vector<KeyDef> &rightKey,
+		const std::vector<KeyDef> &upKey, const std::vector<KeyDef> &downKey) {
+	dpadKeys.clear();
+
+	// Store all directions into one vector for now.  In the future it might be
+	// useful to keep track of the different directions separately.
+	AppendKeys(dpadKeys, leftKey);
+	AppendKeys(dpadKeys, rightKey);
+	AppendKeys(dpadKeys, upKey);
+	AppendKeys(dpadKeys, downKey);
+}
 
 void SetConfirmCancelKeys(const std::vector<KeyDef> &confirm, const std::vector<KeyDef> &cancel) {
 	confirmKeys = confirm;

--- a/input/input_state.cpp
+++ b/input/input_state.cpp
@@ -4,6 +4,7 @@
 
 const char *GetDeviceName(int deviceId) {
 	switch (deviceId) {
+	case DEVICE_ID_ANY: return "any";
 	case DEVICE_ID_DEFAULT: return "built-in";
 	case DEVICE_ID_KEYBOARD: return "kbd";
 	case DEVICE_ID_PAD_0: return "pad1";

--- a/input/input_state.cpp
+++ b/input/input_state.cpp
@@ -51,17 +51,17 @@ int MapPadButtonFixed(int keycode) {
 	}
 }
 
-std::vector<keycode_t> confirmKeys;
-std::vector<keycode_t> cancelKeys;
-std::vector<keycode_t> tabLeftKeys;
-std::vector<keycode_t> tabRightKeys;
+std::vector<KeyDef> confirmKeys;
+std::vector<KeyDef> cancelKeys;
+std::vector<KeyDef> tabLeftKeys;
+std::vector<KeyDef> tabRightKeys;
 
-void SetConfirmCancelKeys(const std::vector<keycode_t> &confirm, const std::vector<keycode_t> &cancel) {
+void SetConfirmCancelKeys(const std::vector<KeyDef> &confirm, const std::vector<KeyDef> &cancel) {
 	confirmKeys = confirm;
 	cancelKeys = cancel;
 }
 
-void SetTabLeftRightKeys(const std::vector<keycode_t> &tabLeft, const std::vector<keycode_t> &tabRight) {
+void SetTabLeftRightKeys(const std::vector<KeyDef> &tabLeft, const std::vector<KeyDef> &tabRight) {
 	tabLeftKeys = tabLeft;
 	tabRightKeys = tabRight;
 }

--- a/input/input_state.h
+++ b/input/input_state.h
@@ -19,6 +19,7 @@
 // Default device IDs
 
 enum {
+	DEVICE_ID_ANY = -1,  // Represents any device ID
 	DEVICE_ID_DEFAULT = 0,  // Old Android
 	DEVICE_ID_KEYBOARD = 1,  // PC keyboard, android keyboards
 	DEVICE_ID_MOUSE = 2,  // PC mouse only (not touchscreen!)
@@ -94,7 +95,7 @@ public:
 		return false;
 	}
 	bool operator == (const KeyDef &other) const {
-		if (deviceId != other.deviceId) return false;
+		if (deviceId != other.deviceId && deviceId != DEVICE_ID_ANY && other.deviceId != DEVICE_ID_ANY) return false;
 		if (keyCode != other.keyCode) return false;
 		return true;
 	}

--- a/input/input_state.h
+++ b/input/input_state.h
@@ -240,9 +240,9 @@ private:
 extern ButtonTracker g_buttonTracker;
 
 // Is there a nicer place for this stuff? It's here to avoid dozens of linking errors in UnitTest..
-extern std::vector<keycode_t> confirmKeys;
-extern std::vector<keycode_t> cancelKeys;
-extern std::vector<keycode_t> tabLeftKeys;
-extern std::vector<keycode_t> tabRightKeys;
-void SetConfirmCancelKeys(const std::vector<keycode_t> &confirm, const std::vector<keycode_t> &cancel);
-void SetTabLeftRightKeys(const std::vector<keycode_t> &tabLeft, const std::vector<keycode_t> &tabRight);
+extern std::vector<KeyDef> confirmKeys;
+extern std::vector<KeyDef> cancelKeys;
+extern std::vector<KeyDef> tabLeftKeys;
+extern std::vector<KeyDef> tabRightKeys;
+void SetConfirmCancelKeys(const std::vector<KeyDef> &confirm, const std::vector<KeyDef> &cancel);
+void SetTabLeftRightKeys(const std::vector<KeyDef> &tabLeft, const std::vector<KeyDef> &tabRight);

--- a/input/input_state.h
+++ b/input/input_state.h
@@ -240,9 +240,12 @@ private:
 extern ButtonTracker g_buttonTracker;
 
 // Is there a nicer place for this stuff? It's here to avoid dozens of linking errors in UnitTest..
+extern std::vector<KeyDef> dpadKeys;
 extern std::vector<KeyDef> confirmKeys;
 extern std::vector<KeyDef> cancelKeys;
 extern std::vector<KeyDef> tabLeftKeys;
 extern std::vector<KeyDef> tabRightKeys;
+void SetDPadKeys(const std::vector<KeyDef> &leftKey, const std::vector<KeyDef> &rightKey,
+		const std::vector<KeyDef> &upKey, const std::vector<KeyDef> &downKey);
 void SetConfirmCancelKeys(const std::vector<KeyDef> &confirm, const std::vector<KeyDef> &cancel);
 void SetTabLeftRightKeys(const std::vector<KeyDef> &tabLeft, const std::vector<KeyDef> &tabRight);

--- a/input/input_state.h
+++ b/input/input_state.h
@@ -79,6 +79,43 @@ enum {
 #define MAX_KEYQUEUESIZE 20
 #endif
 
+// Represents a single bindable key
+class KeyDef {
+public:
+	KeyDef() : deviceId(0), keyCode(0) {}
+	KeyDef(int devId, int k) : deviceId(devId), keyCode(k) {}
+	int deviceId;
+	int keyCode;
+
+	bool operator < (const KeyDef &other) const {
+		if (deviceId < other.deviceId) return true;
+		if (deviceId > other.deviceId) return false;
+		if (keyCode < other.keyCode) return true;
+		return false;
+	}
+	bool operator == (const KeyDef &other) const {
+		if (deviceId != other.deviceId) return false;
+		if (keyCode != other.keyCode) return false;
+		return true;
+	}
+};
+
+// Represents a single bindable axis direction
+struct AxisPos {
+	int axis;
+	float position;
+
+	bool operator < (const AxisPos &other) const {
+		if (axis < other.axis) return true;
+		if (axis > other.axis) return false;
+		return position < other.position;
+	}
+	bool operator == (const AxisPos &other) const {
+		return axis == other.axis && position == other.position;
+	}
+};
+
+
 // Collection of all possible inputs, and automatically computed
 // deltas where applicable.
 struct InputState {

--- a/ui/ui_screen.cpp
+++ b/ui/ui_screen.cpp
@@ -65,7 +65,7 @@ bool UIScreen::key(const KeyInput &key) {
 
 bool UIDialogScreen::key(const KeyInput &key) {
 	bool retval = UIScreen::key(key);
-	if (!retval && (key.flags & KEY_DOWN) && UI::IsEscapeKeyCode(key.keyCode)) {
+	if (!retval && (key.flags & KEY_DOWN) && UI::IsEscapeKey(key)) {
 		if (finished_) {
 			ELOG("Screen already finished");
 		} else {

--- a/ui/view.cpp
+++ b/ui/view.cpp
@@ -222,6 +222,14 @@ void Clickable::Touch(const TouchInput &input) {
 
 // TODO: O/X confirm preference for xperia play?
 
+bool IsDPadKey(const KeyInput &key) {
+	if (dpadKeys.empty()) {
+		return key.keyCode >= NKCODE_DPAD_UP && key.keyCode <= NKCODE_DPAD_RIGHT;
+	} else {
+		return std::find(dpadKeys.begin(), dpadKeys.end(), KeyDef(key.deviceId, key.keyCode)) != dpadKeys.end();
+	}
+}
+
 bool IsAcceptKey(const KeyInput &key) {
 	if (confirmKeys.empty()) {
 		if (key.deviceId == DEVICE_ID_KEYBOARD) {

--- a/ui/view.cpp
+++ b/ui/view.cpp
@@ -222,35 +222,43 @@ void Clickable::Touch(const TouchInput &input) {
 
 // TODO: O/X confirm preference for xperia play?
 
-bool IsAcceptKeyCode(int keyCode) {
+bool IsAcceptKey(const KeyInput &key) {
 	if (confirmKeys.empty()) {
-		return keyCode == NKCODE_SPACE || keyCode == NKCODE_ENTER || keyCode == NKCODE_Z || keyCode == NKCODE_BUTTON_A || keyCode == NKCODE_BUTTON_CROSS || keyCode == NKCODE_BUTTON_1;
+		if (key.deviceId == DEVICE_ID_KEYBOARD) {
+			return key.keyCode == NKCODE_SPACE || key.keyCode == NKCODE_ENTER || key.keyCode == NKCODE_Z;
+		} else {
+			return key.keyCode == NKCODE_BUTTON_A || key.keyCode == NKCODE_BUTTON_CROSS || key.keyCode == NKCODE_BUTTON_1;
+		}
 	} else {
-		return std::find(confirmKeys.begin(), confirmKeys.end(), (keycode_t)keyCode) != confirmKeys.end();
+		return std::find(confirmKeys.begin(), confirmKeys.end(), KeyDef(key.deviceId, key.keyCode)) != confirmKeys.end();
 	}
 }
 
-bool IsEscapeKeyCode(int keyCode) {
+bool IsEscapeKey(const KeyInput &key) {
 	if (cancelKeys.empty()) {
-		return keyCode == NKCODE_ESCAPE || keyCode == NKCODE_BACK || keyCode == NKCODE_BUTTON_CIRCLE || keyCode == NKCODE_BUTTON_B || keyCode == NKCODE_BUTTON_2;
+		if (key.deviceId == DEVICE_ID_KEYBOARD) {
+			return key.keyCode == NKCODE_ESCAPE || key.keyCode == NKCODE_BACK;
+		} else {
+			return key.keyCode == NKCODE_BUTTON_CIRCLE || key.keyCode == NKCODE_BUTTON_B || key.keyCode == NKCODE_BUTTON_2;
+		}
 	} else {
-		return std::find(cancelKeys.begin(), cancelKeys.end(), (keycode_t)keyCode) != cancelKeys.end();
+		return std::find(cancelKeys.begin(), cancelKeys.end(), KeyDef(key.deviceId, key.keyCode)) != cancelKeys.end();
 	}
 }
 
-bool IsTabLeftKeyCode(int keyCode) {
+bool IsTabLeftKey(const KeyInput &key) {
 	if (tabLeftKeys.empty()) {
-		return keyCode == NKCODE_BUTTON_L1;
+		return key.keyCode == NKCODE_BUTTON_L1;
 	} else {
-		return std::find(tabLeftKeys.begin(), tabLeftKeys.end(), (keycode_t)keyCode) != tabLeftKeys.end();
+		return std::find(tabLeftKeys.begin(), tabLeftKeys.end(), KeyDef(key.deviceId, key.keyCode)) != tabLeftKeys.end();
 	}
 }
 
-bool IsTabRightKeyCode(int keyCode) {
+bool IsTabRightKey(const KeyInput &key) {
 	if (tabRightKeys.empty()) {
-		return keyCode == NKCODE_BUTTON_R1;
+		return key.keyCode == NKCODE_BUTTON_R1;
 	} else {
-		return std::find(tabRightKeys.begin(), tabRightKeys.end(), (keycode_t)keyCode) != tabRightKeys.end();
+		return std::find(tabRightKeys.begin(), tabRightKeys.end(), KeyDef(key.deviceId, key.keyCode)) != tabRightKeys.end();
 	}
 }
 
@@ -262,19 +270,19 @@ bool Clickable::Key(const KeyInput &key) {
 	// TODO: Replace most of Update with this.
 	bool ret = false;
 	if (key.flags & KEY_DOWN) {
-		if (IsAcceptKeyCode(key.keyCode)) {
+		if (IsAcceptKey(key)) {
 			down_ = true;
 			ret = true;
 		}
 	}
 	if (key.flags & KEY_UP) {
-		if (IsAcceptKeyCode(key.keyCode)) {
+		if (IsAcceptKey(key)) {
 			if (down_) {
 				Click();
 				down_ = false;
 				ret = true;
 			}
-		} else if (IsEscapeKeyCode(key.keyCode)) {
+		} else if (IsEscapeKey(key)) {
 			down_ = false;
 		}
 	}
@@ -305,7 +313,7 @@ bool StickyChoice::Key(const KeyInput &key) {
 
 	// TODO: Replace most of Update with this.
 	if (key.flags & KEY_DOWN) {
-		if (IsAcceptKeyCode(key.keyCode)) {
+		if (IsAcceptKey(key)) {
 			down_ = true;
 			Click();
 			return true;

--- a/ui/view.h
+++ b/ui/view.h
@@ -801,9 +801,9 @@ void MeasureBySpec(Size sz, float contentWidth, MeasureSpec spec, float *measure
 
 void EventTriggered(Event *e, EventParams params);
 void DispatchEvents();
-bool IsAcceptKeyCode(int keyCode);
-bool IsEscapeKeyCode(int keyCode);
-bool IsTabLeftKeyCode(int keyCode);
-bool IsTabRightKeyCode(int keyCode);
+bool IsAcceptKey(const KeyInput &key);
+bool IsEscapeKey(const KeyInput &key);
+bool IsTabLeftKey(const KeyInput &key);
+bool IsTabRightKey(const KeyInput &key);
 
 }  // namespace

--- a/ui/view.h
+++ b/ui/view.h
@@ -801,6 +801,7 @@ void MeasureBySpec(Size sz, float contentWidth, MeasureSpec spec, float *measure
 
 void EventTriggered(Event *e, EventParams params);
 void DispatchEvents();
+bool IsDPadKey(const KeyInput &key);
 bool IsAcceptKey(const KeyInput &key);
 bool IsEscapeKey(const KeyInput &key);
 bool IsTabLeftKey(const KeyInput &key);

--- a/ui/viewgroup.cpp
+++ b/ui/viewgroup.cpp
@@ -1064,10 +1064,10 @@ void ChoiceStrip::HighlightChoice(unsigned int choice){
 bool ChoiceStrip::Key(const KeyInput &input) {
 	bool ret = false;
 	if (input.flags & KEY_DOWN) {
-		if (IsTabLeftKeyCode(input.keyCode) && selected_ > 0) {
+		if (IsTabLeftKey(input) && selected_ > 0) {
 			SetSelection(selected_ - 1);
 			ret = true;
-		} else if (IsTabRightKeyCode(input.keyCode) && selected_ < (int)views_.size() - 1) {
+		} else if (IsTabRightKey(input) && selected_ < (int)views_.size() - 1) {
 			SetSelection(selected_ + 1);
 			ret = true;
 		}

--- a/ui/viewgroup.cpp
+++ b/ui/viewgroup.cpp
@@ -1192,8 +1192,7 @@ bool KeyEvent(const KeyInput &key, ViewGroup *root) {
 	bool retval = false;
 	// Ignore repeats for focus moves.
 	if ((key.flags & (KEY_DOWN | KEY_IS_REPEAT)) == KEY_DOWN) {
-		// We ignore the device ID here. Anything with a DPAD is OK.
-		if (key.keyCode >= NKCODE_DPAD_UP && key.keyCode <= NKCODE_DPAD_RIGHT) {
+		if (IsDPadKey(key)) {
 			// Let's only repeat DPAD initially.
 			HeldKey hk;
 			hk.key = key.keyCode;
@@ -1213,14 +1212,16 @@ bool KeyEvent(const KeyInput &key, ViewGroup *root) {
 		}
 	}
 	if (key.flags & KEY_UP) {
-		// We ignore the device ID here. Anything with a DPAD is OK.
-		if (key.keyCode >= NKCODE_DPAD_UP && key.keyCode <= NKCODE_DPAD_RIGHT) {
+		// We ignore the device ID here (in the comparator for HeldKey), due to the Ouya quirk mentioned above.
+		if (!heldKeys.empty()) {
 			HeldKey hk;
 			hk.key = key.keyCode;
 			hk.deviceId = key.deviceId;
 			hk.triggerTime = 0.0; // irrelevant
-			heldKeys.erase(hk);
-			retval = true;
+			if (heldKeys.find(hk) != heldKeys.end()) {
+				heldKeys.erase(hk);
+				retval = true;
+			}
 		}
 	}
 


### PR DESCRIPTION
- Moves KeyDef and AxisPos from the PPSSPP code base to native. I figured that having one (deviceId, keyCode) type in native and one in PPSSPP would be even more confusing, and most projects using native would probably want something akin to KeyDef anyway. I also moved AxisPos since having the two in different places would be even more confusing.
- Uses KeyDef for the various keys native keeps track of for navigation, rather than just keycode_t. This avoids issues where different devices use the same keyCode for different things (some controllers seem to use the keyboard arrow key keycodes for buttons).
- Tracks DPad keys for navigation as well. Currently, all directions get stored in one vector, and this vector is queried in the key-repeat logic in input/input_state.cpp, replacing a hardcoded check on keyCode.
- Rewrites the logic for detecting when a held key is released slightly. This is to account for the above but still support Ouya's weird behaviour, hopefully.
